### PR TITLE
make plugin compatible to pelican 3.7.0

### DIFF
--- a/assets/assets.py
+++ b/assets/assets.py
@@ -32,7 +32,7 @@ except ImportError:
 def add_jinja2_ext(pelican):
     """Add Webassets to Jinja2 extensions in Pelican settings."""
 
-    pelican.settings['JINJA_EXTENSIONS'].append(AssetsExtension)
+    pelican.settings['JINJA_ENVIRONMENT']['extensions'].append(AssetsExtension)
 
 
 def create_assets_env(generator):


### PR DESCRIPTION
Must change the way JINJA extension is added due to changes in the 3.7.0 version. 
Not compatible with previous versions.